### PR TITLE
ENH: Use updated AWS EC2 image for GPU testing

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -7,7 +7,7 @@ runners:
     # NVIDIA GPU
     instance_type: g4dn.xlarge
     # Custom-defined Ubuntu AMI with AMD drivers and build tools pre-installed
-    machine_image: ami-0328487742df7e739
+    machine_image: ami-04462a876c33e6acf
     region: us-east-2
     preemptible: false
     # Relevant workflow file

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -26,7 +26,12 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.21.2
+      uses: lukka/get-cmake@v3.21.2      
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     
     - name: Download OpenCL-ICD-Loader
       run: |


### PR DESCRIPTION
Created a new AWS EC2 AMI:
- Doubled the image storage space (8GB -> 16GB)
- Cleaned user directory which previously contained artifacts from testing for other ITK external modules

AMI is Ubuntu 20.04 with OpenCL headers + installed `clinfo` for checking GPU availability.

AMI has public access permissions and appears in the AWS EC2 AMI catalog.

Closes #25. Also resolves newly observed issue where Python is not found by default for building with CMake on GPU runner.