### PR TITLE
ENH: Update Linux Python CI build procedure

### DIFF
--- a/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
+++ b/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
@@ -8,8 +8,13 @@
 #
 #   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 
+MANYLINUX_VERSION="_2_28"
+IMAGE_TAG=20220715-9ce3707
+OPENCL_ICD_LOADER_TAG=v2021.04.29
+OPENCL_HEADERS_TAG=v2021.04.29
+
 # Generate dockcross scripts
-docker run --rm dockcross/manylinux2014-x64:20211006-2a1c5fb > /tmp/dockcross-manylinux-x64
+docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64
 chmod u+x /tmp/dockcross-manylinux-x64
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)
@@ -17,12 +22,12 @@ script_dir=$(cd $(dirname $0) || exit 1; pwd)
 if ! test -d ./OpenCL-ICD-Loader; then
   git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
   pushd OpenCL-ICD-Loader
-  git checkout v2021.04.29
+  git checkout ${OPENCL_ICD_LOADER_TAG}
   popd
   pushd OpenCL-ICD-Loader/inc
   git clone https://github.com/KhronosGroup/OpenCL-Headers
   pushd OpenCL-Headers
-  git checkout v2021.04.29
+  git checkout ${OPENCL_HEADERS_TAG}
   popd
   cp -r OpenCL-Headers/CL ./
   popd

--- a/wrapping/dockcross-manylinux-download-cache.sh
+++ b/wrapping/dockcross-manylinux-download-cache.sh
@@ -7,8 +7,9 @@ curl https://data.kitware.com/api/v1/file/592dd8068d777f16d01e1a92/download -o z
 gunzip -d zstd-1.2.0-linux.tar.gz
 tar xf zstd-1.2.0-linux.tar
 
-curl -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.2.1}/ITKPythonBuilds-linux.tar.zst -O
+curl -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3rc04.post2}/ITKPythonBuilds-linux.tar.zst -O
 ./zstd-1.2.0-linux/bin/unzstd ITKPythonBuilds-linux.tar.zst -o ITKPythonBuilds-linux.tar
+echo "Extracting all files"
 tar xf ITKPythonBuilds-linux.tar
 
 mkdir tools


### PR DESCRIPTION
- Bump `manylinux` image
- Centralize script tags for easier reference/updates

This change along with [https://github.com/clEsperanto/CLIc_prototype/commit/0f82b9f0858a6a9d98337acfa290e3a26023293d](https://github.com/clEsperanto/CLIc_prototype/commit/0f82b9f0858a6a9d98337acfa290e3a26023293d) will close #30 .