### PR TITLE
ENH: Bump version to `v0.2.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-clesperanto',
-    version='0.2.0',
+    version='0.2.1',
     author='NumFOCUS',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.1rc1.post1'
+        r'itk>=5.3rc04.post2'
     ]
     )


### PR DESCRIPTION
Update version number for subsequent tag and PyPI pre-release. Reflects ITK wheel tag already used in building module wheels in CI.