### PR TITLE
ENH: Bump ITK to v5.3rc04.post3

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,8 +3,8 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
-  itk-wheel-tag: "v5.3rc04.post2"
+  itk-git-tag: "171fb2ba33a87041f99328a2f26612ff33aa9cc8"
+  itk-wheel-tag: "v5.3rc04.post3"
   opencl-icd-loader-git-tag: "v2021.04.29"
   opencl-headers-git-tag: "v2021.04.29"
 
@@ -14,9 +14,9 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
@@ -279,7 +279,7 @@ jobs:
         path: ../../im/dist
 
   build-linux-opencl-python-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 2
       matrix:
@@ -300,6 +300,7 @@ jobs:
     - name: 'Build 🐍 Python 📦 package'
       run: |
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
+        export TARBALL_SPECIALIZATION="-manylinux_2_28"
         ./wrapping/dockcross-manylinux-download-cache.sh
         ./wrapping/dockcross-manylinux-build-module-wheels-opencl.sh cp${{ matrix.python-version }}
 
@@ -319,7 +320,7 @@ jobs:
 
     - name: 'Specific XCode version'
       run: |
-        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.21.2
@@ -346,7 +347,7 @@ jobs:
       - build-linux-opencl-python-packages
       - build-macos-opencl-python-packages
       - build-windows-python-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Download Python Packages

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -3,7 +3,7 @@ name: Test GPU
 on: [pull_request]
 
 env:
-  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
+  itk-git-tag: "171fb2ba33a87041f99328a2f26612ff33aa9cc8"
   opencl-icd-loader-git-tag: "v2021.04.29"
   opencl-headers-git-tag: "v2021.04.29"
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-clesperanto',
-    version='0.2.1',
+    version='0.2.2',
     author='NumFOCUS',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.3rc04.post2'
+        r'itk>=5.3rc04.post3'
     ]
     )

--- a/wrapping/dockcross-manylinux-download-cache.sh
+++ b/wrapping/dockcross-manylinux-download-cache.sh
@@ -7,10 +7,12 @@ curl https://data.kitware.com/api/v1/file/592dd8068d777f16d01e1a92/download -o z
 gunzip -d zstd-1.2.0-linux.tar.gz
 tar xf zstd-1.2.0-linux.tar
 
-curl -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3rc04.post2}/ITKPythonBuilds-linux.tar.zst -O
-./zstd-1.2.0-linux/bin/unzstd ITKPythonBuilds-linux.tar.zst -o ITKPythonBuilds-linux.tar
+TARBALL_NAME="ITKPythonBuilds-linux${TARBALL_SPECIALIZATION}.tar"
+curl -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${ITK_PACKAGE_VERSION:=v5.3rc04.post3}/${TARBALL_NAME}.zst -O
+./zstd-1.2.0-linux/bin/unzstd ${TARBALL_NAME}.zst -o ${TARBALL_NAME}
 echo "Extracting all files"
-tar xf ITKPythonBuilds-linux.tar
+tar xf ${TARBALL_NAME}
+rm ${TARBALL_NAME}
 
 mkdir tools
 curl https://data.kitware.com/api/v1/file/5c0aa4b18d777f2179dd0a71/download -o doxygen-1.8.11.linux.bin.tar.gz


### PR DESCRIPTION
Bumps ITK and applies relevant build changes.

See similar updates for building with OpenCL in https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend/pull/58/files