### PR TITLE
ENH: Python test updates

### DIFF
--- a/wrapping/test/CMakeLists.txt
+++ b/wrapping/test/CMakeLists.txt
@@ -1,4 +1,10 @@
 itk_python_add_test(
+  NAME itkCLEImageTestPython
+  COMMAND itkCLEImageTestPython.py
+)
+
+
+itk_python_add_test(
   NAME itkCLEAddImageTestPython
   COMMAND itkCLEAddImageTestPython.py
 )

--- a/wrapping/test/itkCLEAddImageTestPython.py
+++ b/wrapping/test/itkCLEAddImageTestPython.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python3
 
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
 import itertools
 
 import itk
@@ -33,6 +51,8 @@ add_filter.SetInput2(image2)
 add_filter.Update()
 
 output_image = add_filter.GetOutput()
+output_image.Update()
+
 assert(itk.size(output_image) == [width, height])
 assert(itk.spacing(output_image) == [1,1])
 assert(itk.origin(output_image) == [0,0])

--- a/wrapping/test/itkCLEImageTestPython.py
+++ b/wrapping/test/itkCLEImageTestPython.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+import itertools
+
+import itk
+itk.auto_progress(2)
+assert 'CLEsperanto' in dir(itk)
+
+width = 256
+height = 256
+
+# Set up image
+image_type = itk.CLEImage[itk.F,2]
+image_0 = image_type.New()
+print(image_0)
+
+# Test Graft
+image_1 = image_type.New()
+image_1.SetRegions([width,height])
+image_1.Allocate()
+
+image_0.Graft(image_1)
+if image_0.GetPixelContainer() != image_1.GetPixelContainer():
+    raise ValueError('Graft test failed')
+
+# Test FillBuffer
+fill_value = 1.0
+image_1.FillBuffer(fill_value)
+
+for i,j in itertools.product(range(width), range(height)):
+    assert image_1.GetPixel([i,j]) == fill_value
+
+# Test SetPixel
+index = [0,0]
+set_value = 7.0
+image_1.SetPixel(index, set_value)
+for i,j in itertools.product(range(width), range(height)):
+    if [i,j] == index:
+        assert image_1.GetPixel([i,j]) == set_value
+    else:
+        assert image_1.GetPixel([i,j]) == fill_value
+


### PR DESCRIPTION
- Resolve `itkCLEAddImageTestPython` failure where CPU buffer was not updated
- Port `itkCLEImageTestPython` test from C++ to Python for baseline image behavior
- Add copyright to Python files