### PR TITLE
ENH: Resolve `gh-action-pypi-publish` warning

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -365,7 +365,7 @@ jobs:
 
     - name: Publish 🐍 Python 📦 package to PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The `gh-action-pypi-publish@master` branch has been sunset so use tagged version instead instead.

Closes #40 